### PR TITLE
Removes caching from nav partial.

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -40,6 +40,6 @@
       {{ end }}
     </header>
 
-    {{ partialCached "nav" . }}
+    {{ partial "nav" . }}
 
     <main>


### PR DESCRIPTION
The nav partial contains the menu links and adds an `active` style to them, according to the currently open page. If it is cached, the same link will be active all over the site, instead of being highlighted only if its respective page is opened.