### PR TITLE
Change comment icon to fa-comments

### DIFF
--- a/layouts/partials/disqus.html
+++ b/layouts/partials/disqus.html
@@ -1,5 +1,5 @@
 <section class="comments-block">
-      <button id="show-comments" style="display: none;"><i class="fa fa-comments-o"></i> {{ T "comments "}}</button>
+      <button id="show-comments" style="display: none;"><i class="fa fa-comments"></i> {{ T "comments "}}</button>
 </section>
 
 <section id="disqus_thread"></section>


### PR DESCRIPTION
Hi, 
Thanks for maintaining that theme! 

I have wanted to report issue first but issues are not enabled on that fork, can you enable them if you plan to maintain it?

Regarding issue, it looks that `fa-comments-o` is not working. I have no idea what could be wrong, but if I change it to other comment icon it seems to work fine.
If you have an idea how to fix issue with previous one, go ahead and close that PR.