### PR TITLE
bugfix: can't evaluate field disqusShortname in type page.Site

### DIFF
--- a/layouts/partials/disqus.html
+++ b/layouts/partials/disqus.html
@@ -12,7 +12,7 @@
                   return;
 
             var disqus_loaded = false;
-            var disqus_shortname = '{{ .Site.disqusShortname }}';
+            var disqus_shortname = '{{ .Site.DisqusShortname }}';
             var disqus_button = document.getElementById("show-comments");
 
             disqus_button.style.display = "";


### PR DESCRIPTION
when I try open Disqus. I got an error message:
```
execute of template failed: template: partials/disqus.html:15:47: executing "partials/disqus.html" at <.Site.disqusShortname>: can't evaluate field disqusShortname in type page.Site
```