### PR TITLE
Add styling for code highlighted code blocks

### DIFF
--- a/static/css/styles-dark.css
+++ b/static/css/styles-dark.css
@@ -155,6 +155,12 @@ time {
   box-shadow: 0 -1px 0 #bbbbbb inset;
 }
 
+#container main article .highlight pre {
+  overflow-x: auto;
+  font-size: 0.9em;
+  padding: 0.8em;
+}
+
 #container main article pre code {
   font-size: 0.9em;
 }

--- a/static/css/styles-light.css
+++ b/static/css/styles-light.css
@@ -154,6 +154,12 @@ time {
   box-shadow: 0 -1px 0 #bbbbbb inset;
 }
 
+#container main article .highlight pre {
+  overflow-x: auto;
+  font-size: 0.9em;
+  padding: 0.8em;
+}
+
 #container main article pre code {
   font-size: 0.9em;
 }


### PR DESCRIPTION
Currently, highlighted code blocks do not have the same styling as normal code blocks. 

\```
public class AVeryLongClassNameWillOveflowTextWithoutShowingAScrollBar : BugInStyleSheet
{
   
}
\```

\```C#
public class AVeryLongClassNameWillOveflowTextWithoutShowingAScrollBar : BugInStyleSheet
{
   
}
\```

If you use the above markdown you get the following output:
![bug](https://user-images.githubusercontent.com/3967506/76205528-48bd4480-625f-11ea-833d-d892c1a9568a.png)
Note the missing scrollbar.
When you add a highlighted code block the \<pre> gets wrapped in a div which causes the styling to not apply because it only looks for direct descendants of \<article> (#container main article > pre )

This fix applies the relevant styling to a highlighted code block.
![bug-fixed](https://user-images.githubusercontent.com/3967506/76206539-190f3c00-6261-11ea-9513-a8eafa1cd58b.png)
