### PR TITLE
Allow to disable comments on post

### DIFF
--- a/layouts/partials/disqus.html
+++ b/layouts/partials/disqus.html
@@ -16,6 +16,11 @@
             var disqus_button = document.getElementById("show-comments");
 
             var disqus_autoload = {{ .Site.Params.CommentAutoload }};
+            var disable_comment = {{ .Params.disable_comments }};
+
+            if (disable_comment)
+                  return;
+
             disqus_button.style.display = "";
 
             if (disqus_autoload){


### PR DESCRIPTION
This PR allow the user to disable comments on single post/page by adding the `disable_commens: true` property to the Front Matter of the post/page.