### PR TITLE
Allows you to overwrite default included fonts

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ It was originally developed by [b. avianto](https://github.com/avianto/hugo-kier
 - Utilize normalize.css for consistent styling (Cloudflare CDN).
 - Use Google Fonts: Ruda (serif) and Roboto Slab (sans-serif).
 - [Disqus](https://disqus.com) or [Utterances](https://utteranc.es) comments loaded on demand.
-
+- Supports downloading extra [Google Fonts](https://fonts.google.com/).
 
 ## Demo
 

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -36,6 +36,7 @@ pygmentsCodeFences = true
     #homepageLength = 10
     #commentAutoload = true  #This mean reader don't need click, disqus comment autoload
     #mathjax = true #Enable display of mathematics using mathjax (LaTeX syntax)
+    #google_fonts = ["Staatliches"] # Adds additional google fonts
 
 # uncomment to enable the Tags link on the main toolbar
 #  [[menu.main]]

--- a/layouts/partials/header_includes.html
+++ b/layouts/partials/header_includes.html
@@ -10,7 +10,12 @@
 
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css" integrity="sha256-l85OmPOjvil/SOvVt3HnSSjzF1TUMyT9eV0c2BzEGzU=" crossorigin="anonymous" />
   <link rel="stylesheet" href="{{ "fontawesome/css/all.min.css" | absURL }}" />
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Slab|Ruda" />
+  {{ if .Site.Params.google_fonts }}
+    {{ $url_part := (delimit .Site.Params.google_fonts "|") | safeHTMLAttr }}
+    <link {{ printf "href=\"//fonts.googleapis.com/css?family=%s\"" $url_part | safeHTMLAttr }} rel="stylesheet">
+  {{ else}}
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Slab|Ruda" />
+  {{ end }}
   <link rel="stylesheet" type="text/css" href="{{ "css/styles.css" | relURL}}" />
   {{- range .Site.Params.customCSS -}}
     <link rel='stylesheet' href='{{ . | absURL }}'>


### PR DESCRIPTION
- Adds a parameter to replace default included fonts.
- If the new parameter is not used it loads default fonts.

Note: I'm using this feature to overwrite a few aspects of the template
with a custom CSS file.