### PR TITLE
Remove unnecessary styles-without-dark-mode.css

### DIFF
--- a/layouts/partials/header_includes.html
+++ b/layouts/partials/header_includes.html
@@ -24,7 +24,7 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Slab|Ruda" />
   {{ end }}
   {{ if .Site.Params.disableDarkModeCSS }}
-  <link rel="stylesheet" type="text/css" href="{{ "css/styles-without-dark-mode.css" | relURL}}" />
+  <link rel="stylesheet" type="text/css" href="{{ "css/styles-light.css" | relURL}}" />
   {{ else}}
   <link rel="stylesheet" type="text/css" href="{{ "css/styles.css" | relURL}}" />
   {{- end -}}

--- a/static/css/styles-without-dark-mode.css
+++ b/static/css/styles-without-dark-mode.css
@@ -1,1 +1,0 @@
-@import url(./styles-light.css);


### PR DESCRIPTION
I'm not an expert in web-dev by any means, so please tell me if this will break some use case. AFAICT, it does not break `disableDarkModeCSS` nor `customCSS` use cases.