### PR TITLE
Add an empty partial for a user-supplied footer

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -9,6 +9,7 @@
 {{ if .Site.GoogleAnalytics }}
   {{ template "_internal/google_analytics_async.html" . }}
 {{ end }}
+{{ partial "user_footer" . }}
 </body>
 
 </html>


### PR DESCRIPTION
This adds a place for a user to override a vacuous partial and add things to the footer.

Tbh, this will mostly be useful to those who use analytics platforms other than Google analytics, but it's better than having a copy of the whole footer partial slightly modified for that usage.