### PR TITLE
add invisible char filter

### DIFF
--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -23,7 +23,7 @@
        <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
        {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
        <guid>{{ .Permalink }}</guid>
-       <description>{{ .Content | replaceRE `[^\f\t\n\r\v\123\x7F\x{10FFFF}\\\^\$\.\*\+\?\{\}\(\)\[\]\|]` "$1" | html}}</description>
+       <description>{{ .Content | replaceRE `[\x00-\x1F\x7F]` "" | html}}</description>
      </item>
    {{ end }}
  </channel>

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -23,7 +23,7 @@
        <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
        {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
        <guid>{{ .Permalink }}</guid>
-       <description>{{ .Content | html }}</description>
+       <description>{{ .Content | replaceRE `[^\f\t\n\r\v\123\x7F\x{10FFFF}\\\^\$\.\*\+\?\{\}\(\)\[\]\|]` "$1" | html}}</description>
      </item>
    {{ end }}
  </channel>


### PR DESCRIPTION
if markdown exists invisible char, will get below error

```
This page contains the following errors:
error on line 1595 at column 43: PCDATA invalid Char value 8
Below is a rendering of the page up to the first error.
```

so, I want to add replaceRE method filter all invisible char for raw markdown content. 
I'm a re newbie, if you have a good idea, pls tell me.