### PR TITLE
use "X minute read" instead of "X minutes read"

### DIFF
--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -3,7 +3,7 @@ other = "Categories:"
 
 [readingTime]
 one = "One minute read"
-other = "{{.Count}} minutes read"
+other = "{{.Count}} minute read"
 
 [readMore]
 other = "Read more…"


### PR DESCRIPTION
one should rather say "this is a 10 minute read" than "this is a 10 minutes read" in English