### PR TITLE
Add header supplement loading

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -6,6 +6,10 @@
   <title>{{ if and (not .IsHome) (.Title) }}{{ .Params.Title }} - {{ end }}{{ .Site.Title }}</title>
   {{ partial "meta" . }}
   {{ partialCached "header_includes" . -}}
+
+  {{ if (templates.Exists "partials/header_supplement.html") }}
+    {{ partialCached "header_supplement.html" . -}}
+  {{ end }}
 </head>
 
 <body>


### PR DESCRIPTION
This PR adds conditional loading of a supplemental header partial. It makes use of `templates.Exists` (added by https://github.com/gohugoio/hugo/pull/5015) to do this.

This feature allows theme users to extend the theme's `head` block with additional content without having to copy the theme's partials to `layouts/partials/` (and avoid the maintenance burden that would introduce). In my specific case, I want to add a `link` to every generated page.