### PR TITLE
Use partial instead of partialCached

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -8,7 +8,7 @@
   {{ partialCached "header_includes" . -}}
 
   {{ if (templates.Exists "partials/header_supplement.html") }}
-    {{ partialCached "header_supplement.html" . -}}
+    {{ partial "header_supplement.html" . -}}
   {{ end }}
 </head>
 


### PR DESCRIPTION
I am working to de-duplicate some CSS in shortcodes by adding block like the following to my site header template:

```
{{ if .HasShortcode "foo" -}}
<link rel="stylesheet" type="text/css" href="/css/foo.css" />
{{- end }}
```

I spent a while churning trying to figure out why I was _sometimes_ getting the right render, but most times not. I discovered that making the change in this PR fixes the issue. Basically, not every page is going to include all stylesheets, and the first page that actually gets rendered was priming the partial cache.