### PR TITLE
Fix Deprecation Warnings

### DIFF
--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -4,7 +4,9 @@ copyright = "Copyright &copy; 2023 - Author Name"
 canonifyurls = true
 theme = "hugo-kiera"
 
-paginate = 3
+[pagination]
+  pagersize = 3
+  path = 'page'
 
 summaryLength = 30
 enableEmoji = true
@@ -13,7 +15,7 @@ pygmentsCodeFences = true
 #disqusShortname = "myShortName"
 
 # Note: to disable a social network icon delete or comment out the corresponding line
-[author]
+[params.author]
     name = "Example"
     github = "funkydan2/hugo-kiera"
     #gitlab = "username"

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -8,9 +8,9 @@
    <link>{{ .Permalink }}</link>
    <description>Recent content {{ if ne  .Title  .Site.Title }}{{ with .Title }}in {{.}} {{ end }}{{ end }}on {{ .Site.Title }}</description>
    <generator>Hugo -- gohugo.io</generator>{{ with .Site.LanguageCode }}
-   <language>{{.}}</language>{{end}}{{ with .Site.Author.email }}
-   <managingEditor>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Author.email }}
-   <webMaster>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}
+   <language>{{.}}</language>{{end}}{{ with .Site.Params.Author.email }}
+   <managingEditor>{{.}}{{ with $.Site.Params.Author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Params.Author.email }}
+   <webMaster>{{.}}{{ with $.Site.Params.Author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}
    <copyright>{{.}}</copyright>{{end}}{{ if not .Date.IsZero }}
    <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
    {{ with .OutputFormats.Get "RSS" }}
@@ -21,7 +21,7 @@
        <title>{{ .Title }}</title>
        <link>{{ .Permalink }}</link>
        <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
-       {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
+       {{ with .Site.Params.Author.email }}<author>{{.}}{{ with $.Site.Params.Author.name }} ({{.}}){{end}}</author>{{end}}
        <guid>{{ .Permalink }}</guid>
        <description>{{ .Content | replaceRE `[\x00-\x1F\x7F]` "" | html}}</description>
      </item>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -27,9 +27,9 @@
           {{ end }}
         {{- end -}}
         {{- range .Site.Data.social.social_icons -}}
-          {{- if isset $.Site.Author .id }}
+          {{- if isset $.Site.Params.Author .id }}
              <li>
-               <a href="{{ printf .url (index $.Site.Author .id) }}" title="{{ .title }}">
+               <a href="{{ printf .url (index $.Site.Params.Author .id) }}" title="{{ .title }}">
                <i class="{{ .icon }} fa-lg"></i>
                </a>
              </li>

--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -1,7 +1,7 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <meta name="description" content="{{ .Site.Params.description | default "The HTML5 Herald" }}" />
-<meta name="author" content="{{ .Params.Author | default .Site.Author.name }}" />
+<meta name="author" content="{{ .Params.Author | default .Site.Params.Author.name }}" />
 {{- with .OutputFormats.Get "rss" -}}
 	{{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
 {{- end -}}


### PR DESCRIPTION
WARN  deprecated: site config key paginate was deprecated in Hugo v0.128.0 and will be removed in a future release. Use pagination.pagerSize instead.
WARN  deprecated: .Site.Author was deprecated in Hugo v0.124.0 and will be removed in a future release. Use taxonomies instead.

	modified:   exampleSite/hugo.toml
	modified:   layouts/_default/rss.xml
	modified:   layouts/partials/header.html
	modified:   layouts/partials/meta.html

Also updated examplesite for a clean complile