### PR TITLE
Render active pages in footer menu

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -3,4 +3,4 @@
 {{ block "main" . }}
 {{ end }}
 
-{{ partialCached "footer" . }}
+{{ partial "footer" . }}


### PR DESCRIPTION
`partialCached` will cache one version of the footer, and then reuse it for each page. But the footer has the "footer" menu in it, and it should be rendered fresh for each page.

Strongly resembles #2, which fixed the same issue in `nav`.

(Duplicate of #80, where I used the wrong branch and then clobbered it.)